### PR TITLE
Allow chalk to compile

### DIFF
--- a/hw/platform/chalk/chalk_bluetooth.c
+++ b/hw/platform/chalk/chalk_bluetooth.c
@@ -6,7 +6,8 @@
  */
 
 uint8_t hw_bluetooth_init() {
-    
+    bluetooth_init_complete(INIT_RESP_OK);
+    return 0;
 }
 
 void bt_device_request_tx() {

--- a/hw/platform/chalk/platform_config.h
+++ b/hw/platform/chalk/platform_config.h
@@ -16,3 +16,8 @@ extern unsigned char _binary_Resources_chalk_fpga_bin_start;
 #define DISPLAY_FPGA_ADDR &_binary_Resources_chalk_fpga_bin_start
 #define DISPLAY_FPGA_SIZE &_binary_Resources_chalk_fpga_bin_size
 
+#define MEM_REGION_DISPLAY  MEM_REGION_CCRAM
+#define MEM_REGION_RAMFS    MEM_REGION_CCRAM
+#define MEM_REGION_HEAP_OVL MEM_REGION_CCRAM
+#define MEM_REGION_HEAP_WRK 
+#define MEM_REGION_PANIC    MEM_REGION_CCRAM

--- a/hw/platform/snowy/platform_config.h
+++ b/hw/platform/snowy/platform_config.h
@@ -25,3 +25,9 @@ extern unsigned char _binary_Resources_snowy_fpga_bin_start;
 #define BLUETOOTH_MODULE_NAME_LENGTH 0x0d
 #define BLUETOOTH_MODULE_LE_NAME     'P', 'e', 'b', 'b', 'l', 'e', ' ', 'T', 'i', 'm', 'e', 'L', 'E'
 #define BLUETOOTH_MODULE_GAP_NAME    "Pebble Time RblOs"
+
+#define MEM_REGION_DISPLAY  MEM_REGION_CCRAM
+#define MEM_REGION_RAMFS    MEM_REGION_CCRAM
+#define MEM_REGION_HEAP_OVL MEM_REGION_CCRAM
+#define MEM_REGION_HEAP_WRK MEM_REGION_CCRAM
+#define MEM_REGION_PANIC    MEM_REGION_CCRAM

--- a/hw/platform/snowy_family/platform_config_common.h
+++ b/hw/platform/snowy_family/platform_config_common.h
@@ -58,7 +58,8 @@
 /* Use the prefix CCRAM to force the memory of an object to be pushed
  * into memory bank 2. Note bank 2 is NOT DMA capable
  */
-#define CCRAM __attribute__((section(".ccmram")))
+#define MEM_REGION_CCRAM __attribute__((section(".ccmram")))
+
 
 //Snowy uses OC1 for backlight
 #define BL_TIM_CH 1

--- a/hw/platform/snowy_family/snowy_display.c
+++ b/hw/platform/snowy_family/snowy_display.c
@@ -58,7 +58,7 @@
  * This does mean we can't (not that we could) dma from CCRAM to the SPI.
  * It's an unsupported hardware config for stm32 at least
  */
-static uint8_t _frame_buffer[DISPLAY_ROWS * DISPLAY_COLS] CCRAM;
+static uint8_t _frame_buffer[DISPLAY_ROWS * DISPLAY_COLS] MEM_REGION_DISPLAY;
 static uint8_t _column_buffer[DISPLAY_ROWS];
 static uint8_t _display_ready;
 

--- a/hw/platform/snowy_family/snowy_display.c
+++ b/hw/platform/snowy_family/snowy_display.c
@@ -233,6 +233,14 @@ void _snowy_display_init_intn(void)
     stm32_power_release(STM32_POWER_AHB1, RCC_AHB1Periph_GPIOG);
 }
 
+#if defined(REBBLE_PLATFORM_CHALK)
+/* snowy bluetooth handles this interrupt. We dont have that hooked up on chalk */
+void EXTI15_10_IRQHandler(void)
+{
+    EXTI_ClearITPendingBit(EXTI_Line10);
+}
+#endif
+
 static void _snowy_display_request_clocks()
 {
     stm32_power_request(STM32_POWER_APB2, RCC_APB2Periph_SPI6);

--- a/hw/platform/tintin/platform.h
+++ b/hw/platform/tintin/platform.h
@@ -58,7 +58,12 @@
 /* XXX: issue pebble-dev/RebbleOS#43 */
 #define RES_START           0x200C
 
-#define CCRAM
+#define MEM_REGION_DISPLAY
+#define MEM_REGION_RAMFS
+#define MEM_REGION_HEAP_OVL
+#define MEM_REGION_HEAP_WRK
+#define MEM_REGION_PANIC
+
 
 static inline uint8_t is_interrupt_set(void)
 {

--- a/rcore/appmanager.c
+++ b/rcore/appmanager.c
@@ -47,8 +47,8 @@ static StackType_t _app_thread_manager_stack[APP_THREAD_MANAGER_STACK_SIZE];  //
  * or at least add dynamicness to it. But honestly we have 3 threads
  * max at the moment, so if we get there, maybe */
 static uint8_t _heap_app[MEMORY_SIZE_APP_HEAP];
-static CCRAM uint8_t _heap_worker[MEMORY_SIZE_WORKER_HEAP];
-static CCRAM uint8_t _heap_overlay[MEMORY_SIZE_OVERLAY_HEAP];
+static MEM_REGION_HEAP_WRK uint8_t _heap_worker[MEMORY_SIZE_WORKER_HEAP];
+static MEM_REGION_HEAP_OVL uint8_t _heap_overlay[MEMORY_SIZE_OVERLAY_HEAP];
 
 /* keep these stacks off CCRAM */
 static StackType_t _stack_app[MEMORY_SIZE_APP_STACK];

--- a/rcore/debug.c
+++ b/rcore/debug.c
@@ -14,7 +14,7 @@
 
 int in_panic = 0;
 
-static StackType_t _panic_stack[PANIC_STACK_SIZE] CCRAM;
+static StackType_t _panic_stack[PANIC_STACK_SIZE] MEM_REGION_PANIC;
 
 __attribute__((__noreturn__)) static void _panic(const char *s) {
     in_panic = 1;

--- a/rcore/rebbleos.c
+++ b/rcore/rebbleos.c
@@ -71,7 +71,7 @@ static void _os_thread(void *pvParameters)
     platform_init_late();
     rcore_watchdog_init_late();
     KERN_LOG("OS", APP_LOG_LEVEL_INFO,  "Watchdog is ticking");
-    //_module_init(bluetooth_init,        "Bluetooth");
+    _module_init(bluetooth_init,        "Bluetooth");
     power_init();
     KERN_LOG("init", APP_LOG_LEVEL_INFO, "Power Init");
     SYS_LOG("OS", APP_LOG_LEVEL_INFO,   "Init: Main hardware up. Starting OS modules");

--- a/rcore/rebbleos.c
+++ b/rcore/rebbleos.c
@@ -71,7 +71,7 @@ static void _os_thread(void *pvParameters)
     platform_init_late();
     rcore_watchdog_init_late();
     KERN_LOG("OS", APP_LOG_LEVEL_INFO,  "Watchdog is ticking");
-    _module_init(bluetooth_init,        "Bluetooth");
+    //_module_init(bluetooth_init,        "Bluetooth");
     power_init();
     KERN_LOG("init", APP_LOG_LEVEL_INFO, "Power Init");
     SYS_LOG("OS", APP_LOG_LEVEL_INFO,   "Init: Main hardware up. Starting OS modules");

--- a/rcore/service/blob_db_ramfs.c
+++ b/rcore/service/blob_db_ramfs.c
@@ -17,7 +17,7 @@
 /* RAM FS */
 #define MSG_HEAP_SIZE 10000
 
-static uint8_t _ramfs_heap[MSG_HEAP_SIZE] CCRAM;
+static uint8_t _ramfs_heap[MSG_HEAP_SIZE] MEM_REGION_RAMFS;
 static qarena_t *_ramfs_arena;
 
 static list_head _ramfs_head = LIST_HEAD(_ramfs_head);


### PR DESCRIPTION
Add interrupt handler for chalk display. 
Add memory defines to pin data to CCRAM based on platform
Fixes issue #79