### PR TITLE
Update Build Guides

### DIFF
--- a/docs/arch_build.md
+++ b/docs/arch_build.md
@@ -1,8 +1,11 @@
 # Building on Arch Linux and It's Derivatives
 
-The following builds RebbleOS on Arch Linux and Parabola once the Pebble SDK is installed:
+## Prerequisites
 
-Note: You will need to aquire the FPGA blobs from the [discord](discord.gg/aRUAYFN) before building.
+Before building RebbleOS you will need the [Pebble SDK](#PebbleSDK) and if you wish to run the firmware in `qemu`, you'll need to make the [resources](#Qemu-Resources)
+
+
+## Building Rebble OS
 
 ```sh
     git clone https://github.com/pebble-dev/RebbleOS.git
@@ -24,7 +27,7 @@ directory for the SDK using the following.
 ```sh
     mkdir ~/pebble-dev/
     cd ~/pebble-dev/
-    wget https://s3.amazonaws.com/assets.getpebble.com/pebble-tool/pebble-sdk-4.5-linux64.tar.bz2
+    wget https://developer.rebble.io/s3.amazonaws.com/assets.getpebble.com/pebble-tool/pebble-sdk-4.5-linux64.tar.bz2
     tar -jxf pebble-sdk-4.5-linux64.tar.bz2
     echo 'export PATH=~/pebble-dev/pebble-sdk-4.5-linux64/bin:$PATH' >> ~/.bash_profile
     . ~/.bash_profile
@@ -35,7 +38,6 @@ directory for the SDK using the following.
     cd ~/pebble-dev/pebble-sdk-4.5-linux64
     virtualenv .env
     source .env/bin/activate
-    sed -i 's/https:\/\/s3-us-west-2.amazonaws.com\/pebble-sdk-homebrew\/pypkjs-1.0.6.tar.gz/https:\/\/github.com\/ltpitt\/vagrant-pebble-sdk\/blob\/master\/pypkjs-1.0.6.tar.gz?raw=true/g' requirements.txt
     pip2 install -r requirements.txt
     deactivate
     mkdir ~/.pebble-sdk/
@@ -44,4 +46,25 @@ directory for the SDK using the following.
     pebble ping --emulator aplite
 ```
 
-As the SDK is no longer available from an official source, this example uses an archived version from [this](https://github.com/aveao/PebbleArchive/) GitHub repository
+## Qemu Resources
+
+Before building RebbleOS for the first time you will need to run the [Utilities/mk_resources.sh](Utilities/mk_resources.sh) script.
+
+```sh
+    cd ~/pebble-dev/RebbleOS/
+    mkdir Resources
+```
+
+At this point, you will need to visit the [Discord](http://discord.gg/aRUAYFN) and download the FPGA files and place them in the new Resources folder we just made.
+Then continue with the steps below.
+
+    
+```sh
+    cd ~/pebble-dev/RebbleOS/Utilities/
+    ./mk_resources.sh ~/.pebble-sdk/SDKs/4.3/sdk-core/pebble
+    cp Resources/* ../Resources/
+```
+
+That's it you're now ready to build! Head back to the [top](#Building-Rebble-OS)
+
+    

--- a/docs/debian_build.md
+++ b/docs/debian_build.md
@@ -1,14 +1,20 @@
 # Building on Debian Stretch
 
+## Prerequisites
+
+Before building RebbleOS you will need the [Pebble SDK](#PebbleSDK) and if you wish to run the firmware in `qemu`, you'll need to make the [resources](#Qemu-Resources)
+
+## Building Rebble OS
 The following builds RebbleOS on Debian Stretch:
 
 ```sh
     apt install -y gcc-arm-none-eabi
     git clone https://github.com/pebble-dev/RebbleOS.git
-    cd FreeRTOS-Pebble
+    cd RebbleOS
     git submodule update --init --recursive
     make
 ```
+## PebbleSDK
 
 The Pebble SDK is a prerequisite for portions of RebbleOS. The
 SDK is available [here](https://developer.rebble.io/developer.pebble.com/sdk/download/index.html).
@@ -30,7 +36,6 @@ directory for the SDK using the following.
     cd ~/pebble-dev/pebble-sdk-4.5-linux64
     virtualenv .env
     source .env/bin/activate
-    sed -i 's/https:\/\/s3-us-west-2.amazonaws.com\/pebble-sdk-homebrew\/pypkjs-1.0.6.tar.gz/https:\/\/github.com\/ltpitt\/vagrant-pebble-sdk\/blob\/master\/pypkjs-1.0.6.tar.gz?raw=true/g' requirements.txt
     pip install -r requirements.txt
     deactivate
     mkdir ~/.pebble-sdk/
@@ -39,4 +44,25 @@ directory for the SDK using the following.
     pebble ping --emulator aplite
 ```
 
-As the SDK is no longer available from an official source, this example uses an archived version from [this](https://github.com/aveao/PebbleArchive/) GitHub repository. URL for the pypkjs module is also used from the [backup repository](https://github.com/ltpitt/vagrant-pebble-sdk).
+## Qemu Resources
+
+Before building RebbleOS for the first time you will need to run the [Utilities/mk_resources.sh](Utilities/mk_resources.sh) script.
+
+```sh
+    cd ~/pebble-dev/RebbleOS/
+    mkdir Resources
+```
+
+At this point, you will need to visit the [Discord](http://discord.gg/aRUAYFN) and download the FPGA files and place them in the new Resources folder we just made.
+Then continue with the steps below.
+
+    
+```sh
+    cd ~/pebble-dev/RebbleOS/Utilities/
+    ./mk_resources.sh ~/.pebble-sdk/SDKs/4.3/sdk-core/pebble
+    cp Resources/* ../Resources/
+```
+
+That's it you're now ready to build! Head back to the [top](#Building-Rebble-OS)
+
+    

--- a/docs/debian_build.md
+++ b/docs/debian_build.md
@@ -28,7 +28,7 @@ directory for the SDK using the following.
     pip install virtualenv
     pip install --upgrade pip
     cd ~/pebble-dev/pebble-sdk-4.5-linux64
-    virtualenv --no-site-packages .env
+    virtualenv .env
     source .env/bin/activate
     sed -i 's/https:\/\/s3-us-west-2.amazonaws.com\/pebble-sdk-homebrew\/pypkjs-1.0.6.tar.gz/https:\/\/github.com\/ltpitt\/vagrant-pebble-sdk\/blob\/master\/pypkjs-1.0.6.tar.gz?raw=true/g' requirements.txt
     pip install -r requirements.txt

--- a/docs/mac_build.md
+++ b/docs/mac_build.md
@@ -3,14 +3,14 @@
 The following builds RebbleOS on macOS:
 
     git clone https://github.com/pebble-dev/RebbleOS.git
-    cd FreeRTOS-Pebble
+    cd RebbleOS
     git submodule update --init --recursive
     make
 
 The Pebble SDK is a prerequisite for portions of RebbleOS. The
-SDK is available at <https://developer.pebble.com/sdk/download/>.
+SDK is available at <https://developer.rebble.io/developer.pebble.com/sdk/download/index.html#mac-os-x>.
 On macOS you can install the SDK with `brew`
 
     brew install pebble/pebble-sdk/pebble-sdk
 
-If you don't use `brew` (or prefer not to) you can [install the SDK manually](https://developer.pebble.com/sdk/install/mac/).
+If you don't use `brew` (or prefer not to) you can [install the SDK manually](https://developer.rebble.io/developer.pebble.com/sdk/install/mac/index.html).

--- a/docs/windows_build.md
+++ b/docs/windows_build.md
@@ -5,30 +5,15 @@ So unfortunately there is no known way (yet), to fully work on Windows while wor
 ## Setting up a virtual machine 
 
 - Install [VirtualBox](http://www.virtualbox.org/)
-- Download Linux ISO file (Ubuntu 16.04.3 LTS) from [their website](https://www.ubuntu.com/download/desktop)
+- Download the Ubuntu's ISO from [their website](https://www.ubuntu.com/download/desktop)
 - Inside virtualbox install Ubuntu
 - You propably want to install the guest additions from VirtualBox
 - Once inside the booted Ubuntu, open a terminal for further install steps
 
 ### Install pebble SDK
 
-For installing the pebble sdk, please see the instructions in the [debian build documentation](https://github.com/ginge/FreeRTOS-Pebble/blob/master/docs/debian_build.md)
+For installing the pebble sdk and building on debian/ubuntu, please see the instructions in the [debian build documentation](https://github.com/pebble-dev/RebbleOS/blob/master/docs/debian_build.md)
 
-### Setting up rebble development environment on Ubuntu
-
-```sh
-cd ~/pebble-dev/
-git clone https://github.com/pebble-dev/RebbleOS.git
-cd FreeRTOS-Pebble
-./Utilities/mk_resources.sh ~/.pebble-sdk/SDKs/current/sdk-core/pebble/
-cd Resources
-wget # find the URLs of the fpga files in the `#firmware` channel in the Rebble Discord
-cd ..
-make
-make snowy_qemu
-```
-
-That is all you need to develop for the Rebble firmware. You can use `make snowy_gdb` in a second terminal to attach GDB to your running emulator.
 
 ## Setting up a development environment on Windows
 


### PR DESCRIPTION
Small fixes to the build docs ~~for debian~~
--no-site-packages is now deprecated and the default for virtualenv
Removed sed command since we now have the AWS bucket!
Also added a section explaining how to make resources. Also added instructions on placing the FPGA's in Resources