### PR TITLE
Add file replacement test

### DIFF
--- a/rcore/fs_test.c
+++ b/rcore/fs_test.c
@@ -74,5 +74,54 @@ TEST(fs_two_files) {
     *artifact = 0;
     return TEST_PASS;
 }
+/*
+Tests the file_replacing logic,
+in all of its forms (create a file with contents A; create a file replacing that file with contents B;
+open the file for read and make sure you get contents A; do the 'finish replacing' operation;
+open the file for read and make sure you get contents B;
+*/
+TEST(fs_replace_file_basic) {
+    struct fd fd, *fdp;
+    struct file file;
+    int rv = TEST_PASS;
+
+    *artifact = 0;
+
+    //create a file with contents a
+    fdp = fs_creat(&fd, "hello", 5);
+       if (!fdp) { *artifact = 1; return TEST_FAIL; }
+       fs_write(&fd, "Hello", 5);
+
+    //create a file replacing that file with contents B
+    rv = fs_find_file(&file, "hello");
+    if (rv < 0) { *artifact = 2; return TEST_FAIL; }
+    fdp = fs_creat_replacing(&fd, "hello", 5, &file);
+    fs_write(&fd, "World", 5);
+
+    //open the file for read and make sure you get contents A;
+    char buf[5];
+
+    rv = fs_find_file(&file, "hello");
+    if (rv < 0) { *artifact = 3; return TEST_FAIL; }
+
+    fs_open(&fd, &file);
+    rv = fs_read(&fd, buf, 5);
+    if (memcmp(buf, "Hello", 5)) { *artifact = 4; return TEST_FAIL; }
+
+    //do the 'finish replacing' operation;
+    fs_mark_written(fdp);
+
+    //open the file for read and make sure you get contents B;
+    rv = fs_find_file(&file, "hello");
+        if (rv < 0) { *artifact = 5; return TEST_FAIL; }
+
+        fs_open(&fd, &file);
+        rv = fs_read(&fd, buf, 5);
+        if (memcmp(buf, "World", 5)) { *artifact = 6; return TEST_FAIL; }
+
+    *artifact = 0;
+    return TEST_PASS;
+}
+
 
 #endif

--- a/tests/snowy/testplan.py
+++ b/tests/snowy/testplan.py
@@ -21,5 +21,6 @@ testplan = [
     Test("Filesystem: find nonexistent file", testname = b'fs_find_noent', golden = 0),
     Test("Filesystem: basic create test", testname = b'fs_creat_basic', golden = 0),
     Test("Filesystem: I/O on two files", testname = b'fs_two_files', golden = 0),
+    Test("Filesystem: basic file replacement test", testname = b'fs_replace_file_basic', golden = 0),
     Test("Blobdb: basic", testname = b'blobdb_basic', golden = 0),
 ]


### PR DESCRIPTION
Add file replacement test:
Tests the file_replacing logic,
in all of its forms (create a file with contents A; create a file replacing that file with contents B;
open the file for read and make sure you get contents A; do the 'finish replacing' operation;
open the file for read and make sure you get contents B;