### PR TITLE
WIP fs: Make it so mark_written has to be used

### DIFF
--- a/rcore/fs.c
+++ b/rcore/fs.c
@@ -525,8 +525,6 @@ struct fd *fs_creat_replacing(struct fd *fd, const char *name, size_t bytes, con
                 filehdr.flag_2 &= ~HDR_FLAG_2_HAS_FILENAME;
             assert(strlen(name) < MAX_FILENAME_LEN);
             filehdr.filename_len = strlen(name);
-            if (!previous)
-                filehdr.st_tmp_file = 0x0;
             
             int rv = _fs_write_page_ofs(pg, 0, &filehdr, sizeof(filehdr));
             assert(rv >= 0);

--- a/rcore/fs_test.c
+++ b/rcore/fs_test.c
@@ -50,10 +50,12 @@ TEST(fs_two_files) {
     fdp = fs_creat(&fd1, "hello", 5);
     if (!fdp) { *artifact = 1; return TEST_FAIL; }
     fs_write(&fd1, "Hello", 5);
+    fs_mark_written(fdp);
     
     fdp = fs_creat(&fd2, "world", 5);
     if (!fdp) { *artifact = 2; return TEST_FAIL; }
     fs_write(&fd2, "World", 5);
+    fs_mark_written(fdp);
     
     char buf[5];
 
@@ -89,8 +91,9 @@ TEST(fs_replace_file_basic) {
 
     //create a file with contents a
     fdp = fs_creat(&fd, "hello", 5);
-       if (!fdp) { *artifact = 1; return TEST_FAIL; }
-       fs_write(&fd, "Hello", 5);
+    if (!fdp) { *artifact = 1; return TEST_FAIL; }
+    fs_write(&fd, "Hello", 5);
+    fs_mark_written(fdp);
 
     //create a file replacing that file with contents B
     rv = fs_find_file(&file, "hello");
@@ -113,11 +116,11 @@ TEST(fs_replace_file_basic) {
 
     //open the file for read and make sure you get contents B;
     rv = fs_find_file(&file, "hello");
-        if (rv < 0) { *artifact = 5; return TEST_FAIL; }
+    if (rv < 0) { *artifact = 5; return TEST_FAIL; }
 
-        fs_open(&fd, &file);
-        rv = fs_read(&fd, buf, 5);
-        if (memcmp(buf, "World", 5)) { *artifact = 6; return TEST_FAIL; }
+    fs_open(&fd, &file);
+    rv = fs_read(&fd, buf, 5);
+    if (memcmp(buf, "World", 5)) { *artifact = 6; return TEST_FAIL; }
 
     *artifact = 0;
     return TEST_PASS;

--- a/rcore/fs_test.c
+++ b/rcore/fs_test.c
@@ -74,5 +74,54 @@ TEST(fs_two_files) {
     *artifact = 0;
     return TEST_PASS;
 }
+/*
+Tests the file_replacing logic,
+in all of its forms (create a file with contents A; create a file replacing that file with contents B;
+open the file for read and make sure you get contents A; do the 'finish replacing' operation;
+open the file for read and make sure you get contents B;
+*/
+TEST(fs_replace_file_basic) {
+    struct fd fd, *fdp;
+    struct file file;
+    int rv = TEST_PASS;
+
+    *artifact = 0;
+
+    //create a file with contents a
+    fdp = fs_creat(&fd, "hello", 5);
+       if (!fdp) { *artifact = 1; return TEST_FAIL; }
+       fs_write(&fd, "Hello", 5);
+
+    //create a file replacing that file with contents B
+    rv = fs_find_file(&file, "hello");
+    if (rv < 0) { *artifact = 2; return TEST_FAIL; }
+    fdp = fs_creat_replacing(&fd, "hello", 5, &file);
+    fs_write(&fd, "World", 5);
+
+    //open the file for read and make sure you get contents A;
+    char buf[5];
+
+    rv = fs_find_file(&file, "hello");
+    if (rv < 0) { *artifact = 3; return TEST_FAIL; }
+
+    fs_open(&fd, &file);
+    rv = fs_read(&fd, buf, 5);
+    if (memcmp(buf, "Hello", 5)) { *artifact = 4; return TEST_FAIL; }
+
+    //do the 'finish replacing' operation;
+    fs_mark_written(fdp);
+
+    //open the file for read and make sure you get contents B;
+    rv = fs_find_file(&file, "hello");
+        if (rv < 0) { *artifact = 5; return TEST_FAIL; }
+
+        fs_open(&fd, &file);
+        rv = fs_read(&fd, buf, 5);
+        if (memcmp(buf, "World", 5)) { *artifact = 6; return TEST_FAIL; }
+
+    *artifact = 0;
+    return TEST_PASS;
+}
+
 
 #endif

--- a/rcore/service/blob_db.c
+++ b/rcore/service/blob_db.c
@@ -410,6 +410,7 @@ uint8_t blobdb_insert(uint16_t database_id, uint8_t *key, uint16_t key_size, uin
             LOG_ERROR("nope, that did not work either, I give up");
             return Blob_DatabaseFull;
         }
+        fs_mark_written(&fd);
     }
 
     int pos = 0;

--- a/tests/snowy/testplan.py
+++ b/tests/snowy/testplan.py
@@ -21,5 +21,6 @@ testplan = [
     Test("Filesystem: find nonexistent file", testname = b'fs_find_noent', golden = 0),
     Test("Filesystem: basic create test", testname = b'fs_creat_basic', golden = 0),
     Test("Filesystem: I/O on two files", testname = b'fs_two_files', golden = 0),
+    Test("Filesystem: basic file replacement test", testname = b'fs_replace_file_basic', golden = 0),
     Test("Blobdb: basic", testname = b'blobdb_basic', golden = 0),
 ]


### PR DESCRIPTION
Changed the semantics of fs_creat/fs_creat_replacing to always wait to clear tmp_file until fs_mark_written.