### PR TITLE
Makefile GCC Checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 
 # Do not override this here!  Override this in localconfig.mk.
 ifeq ($(shell uname -s),Darwin)
-PEBBLE_TOOLCHAIN_PATH ?= /usr/local/Cellar/pebble-toolchain/2.0/arm-cs-tools/bin
+PEBBLE_TOOLCHAIN_PATH ?= /usr/local/bin
 else
 PEBBLE_TOOLCHAIN_PATH ?= /usr/bin
 endif
@@ -56,7 +56,6 @@ VIRTUALENV = $(BUILD)/python_env
 VPYTHON3 = $(VIRTUALENV)/bin/python3
 
 all: $(PLATFORMS)
-
 #########################################
 # Turn platforms into testable platforms.
 #
@@ -227,7 +226,10 @@ endif
 	$(call SAY,OBJCOPY $@)
 	$(QUIET)$(PFX)objcopy $< -O binary $@
 
+# Check to make sure user has the compiler installed, and if it's the correct version if so.
 $(BUILD)/version.c:
+	@if ! [ -f $(CC) ]; then echo "${RED}Error: It does not appear that you have the gcc-arm-none-eabi compiler installed in '$(PEBBLE_TOOLCHAIN_PATH)'.${STOP}"; exit 1; fi
+
 	$(call SAY,VERSION $@)
 	$(QUIET)mkdir -p $(dir $@)
 	$(QUIET)rm -f $@

--- a/rcore/rebbleos.h
+++ b/rcore/rebbleos.h
@@ -30,6 +30,13 @@
 
 #define VERSION "v0.0.0.2"
 
+//Let's make sure the user is using an 'up to date' version of the compiler
+
+#if __GNUC__ < 8
+    #error It appears you are using a version of arm-none-eabi-gcc that is incompatible with with the RebbleOS project. \
+    Please find an updated version by using your respective package manager or going to the developer.arm.com download page.
+#endif
+
 // Public API functions as exposed through the various layers
 
 // Reset the watchdog timer manually


### PR DESCRIPTION
- Updated default MacOS arm GCC path to look at /usr/local/bin so users using package managers like homebrew can utilize repos like [this](https://github.com/ARMmbed/homebrew-formulae) since the pebble homebrew package seems to be borked for now. (If this is approved I will do an overhaul of the MacOS build instructions.)

- Added line in makefile to make sure user actually has GCC installed, and if not it displays a message why the build failed (gcc couldn't be found!). 

- Using the built in GCC macros (thanks @jwise!) , rebbleos.h now checks to make sure if the version of gcc is a 'compatible' one, we no longer want to keep using the one packaged with the Pebble SDK. I have gone ahead and made the lowest version acceptable version 8.0.0. Let me know if rebbleos.h is the best place to put this, otherwise it can be moved up or down in the build process.