### PR TITLE
Protocol more

### DIFF
--- a/rcore/appmanager.h
+++ b/rcore/appmanager.h
@@ -79,8 +79,6 @@ enum {
 
 /* in appmanager.c */
 uint8_t appmanager_init(void);
-void appmanager_timer_add(CoreTimer *timer, app_running_thread *thread);
-void appmanager_timer_remove(CoreTimer *timer, app_running_thread *thread);
 void app_event_loop(void);
 bool appmanager_post_generic_thread_message(AppMessage *am, TickType_t timeout);
 app_running_thread *appmanager_get_current_thread(void);
@@ -117,8 +115,11 @@ bool appmanager_is_app_shutting_down(void);
 bool appmanager_is_app_running(void);
 
 bool appmanager_post_generic_app_message(AppMessage *am, TickType_t timeout);
-void appmanager_timer_expired(app_running_thread *thread);
-TickType_t appmanager_timer_get_next_expiry(app_running_thread *thread);
+
+void appmanager_timer_add(CoreTimer **timer_head, CoreTimer *timer);
+void appmanager_timer_remove(CoreTimer **timer_head, CoreTimer *timer);
+void appmanager_timer_expired(CoreTimer **timer_head, CoreTimer *timer);
+TickType_t appmanager_timer_get_next_expiry(CoreTimer *timer_head);
 
 /* in appmanager_app.c */
 App *appmanager_get_app_by_name(char *app_name);

--- a/rcore/appmanager_app_runloop.c
+++ b/rcore/appmanager_app_runloop.c
@@ -171,13 +171,13 @@ void app_event_loop(void)
     /* App is now fully initialised and inside the runloop. */
     for ( ;; )
     {
-        next_timer = appmanager_timer_get_next_expiry(_this_thread);
+        next_timer = appmanager_timer_get_next_expiry(_this_thread->timer_head);
 
         if (next_timer == 0)
         {
-            appmanager_timer_expired(_this_thread);
+            appmanager_timer_expired(&_this_thread->timer_head, _this_thread->timer_head);
             appmanager_post_draw_message(0);
-            next_timer = appmanager_timer_get_next_expiry(_this_thread);
+            next_timer = appmanager_timer_get_next_expiry(_this_thread->timer_head);
         }
         if (next_timer < 0)
             next_timer = HEARTBEAT_INTERVAL;

--- a/rcore/overlay_manager.c
+++ b/rcore/overlay_manager.c
@@ -362,16 +362,16 @@ static void _overlay_thread(void *pvParameters)
     
     while(1)
     {
-        TickType_t next_timer = appmanager_timer_get_next_expiry(_this_thread);
+        TickType_t next_timer = appmanager_timer_get_next_expiry(_this_thread->timer_head);
 
         if(next_timer == 0) 
         {
-            appmanager_timer_expired(_this_thread);
+            appmanager_timer_expired(&_this_thread->timer_head, _this_thread->timer_head);
             /* When we need to update draw, we post it to the main app. This way
              * we guarantee the background is drawn first.
              * App thread will then defer back to this thread to draw any overlays */
             appmanager_post_draw_message(1);
-            next_timer = appmanager_timer_get_next_expiry(_this_thread);
+            next_timer = appmanager_timer_get_next_expiry(_this_thread->timer_head);
         }
         if (next_timer < 0)
             next_timer = portMAX_DELAY;

--- a/rcore/protocol/protocol_transfer.c
+++ b/rcore/protocol/protocol_transfer.c
@@ -30,13 +30,20 @@
 #define MODULE_TYPE "SYS"
 #define LOG_LEVEL RBL_LOG_LEVEL_DEBUG //RBL_LOG_LEVEL_ERROR
 
-static uint8_t _transfer_state = 0;
-static size_t _total_size = 0;
-static size_t _bytes_transferred = 0;
-static uint32_t _cookie = 0;
-static uint8_t _transfer_type;
-static struct fd _fd;
+typedef struct bytes_transaction_t {
+    uint8_t transfer_state;
+    size_t total_size;
+    size_t bytes_transferred;
+    uint32_t cookie;
+    uint8_t transfer_type;
+    struct fd fd;
+    ProtocolTimer *timer;
+    ProtocolTransportSender transport;
+} bytes_transaction;
 
+static bytes_transaction *_txn = NULL;
+static void _transfer_terminated(RebblePacket packet);
+static void _transfer_timeout(ProtocolTimer *timer);
 
 enum {
     TransferType_Firmware        = 0x01,
@@ -129,10 +136,20 @@ void protocol_process_transfer(const RebblePacket packet)
 
      switch (data[0]) {
         case PutBytesInit:
-            if (_transfer_state != 0) {
+            LOG_INFO("PUT INIT");          
+
+            if (_txn && _txn->transfer_state != 0) {
                 LOG_ERROR("Invalid state for receiving data");
                 goto error;
             }
+
+            _txn->transport = packet_get_transport(packet);
+            if (_txn)
+                remote_free(_txn);
+
+            _txn = mem_heap_alloc(&mem_heaps[HEAP_LOWPRIO], sizeof(bytes_transaction));
+            memset(_txn, 0, sizeof(bytes_transaction));
+
             if (protocol_transaction_lock(200) < 0) {
                 LOG_ERROR("failed to acquire bulk xfer transaction lock");
                 goto error;
@@ -140,17 +157,16 @@ void protocol_process_transfer(const RebblePacket packet)
 
             _transfer_put_app_init_header *hdr = (_transfer_put_app_init_header *)data;
             LOG_INFO("PUT INIT cmd %d, sz %d t %d id %d", hdr->command, ntohl(hdr->total_size), hdr->data_type, ntohl(hdr->app_id));
-            _total_size = ntohl(hdr->total_size);
-            _transfer_state = PutBytesInit;
+            _txn->total_size = ntohl(hdr->total_size);
+            _txn->transfer_state = PutBytesInit;
             
             char buf[16];
             char sel[6];
-            _transfer_type = hdr->data_type & 0x7F;
-            _bytes_transferred = 0;
+            _txn->transfer_type = hdr->data_type & 0x7F;
             
-            if (_transfer_type == TransferType_AppExecutable)
+            if (_txn->transfer_type == TransferType_AppExecutable)
                 snprintf(sel, 4, "app");
-            else if (_transfer_type == TransferType_AppResource)
+            else if (_txn->transfer_type == TransferType_AppResource)
                 snprintf(sel, 4, "res");
             else
                 snprintf(sel, 4, "fle"); //??
@@ -158,91 +174,96 @@ void protocol_process_transfer(const RebblePacket packet)
             snprintf(buf, 16, "@%08x/%s", ntohl(hdr->app_id), sel);
             
             struct file file;
-            if (fs_find_file(&file, buf) >= 0)
-            {
+            if (fs_find_file(&file, buf) >= 0) {
                 /* XXX delete it? */
                 LOG_ERROR("File %s already exists. Fail!", buf);
                 goto error;
             }
                         
-            if (fs_creat(&_fd, buf, _total_size) == NULL) {
+            if (fs_creat(&_txn->fd, buf, _txn->total_size) == NULL) {
                 LOG_ERROR("Couldn't create %s!", buf);
                 goto error;
             }
+
+            _txn->timer = protocol_service_timer_create(_transfer_timeout, 100);
+            protocol_service_timer_start(_txn->timer, 100);
             _send_ack(packet, 0);
             break;
             
         case PutBytesTransfer:
             LOG_DEBUG("Data Transfer Started");
+            protocol_service_timer_cancel(_txn->timer);
             _transfer_put_header *nhdr = (_transfer_put_header *)data;
             size_t data_size = ntohl(nhdr->data_size);
             
-            if (_transfer_state != PutBytesInit)
-            {
+            if (_txn->transfer_state != PutBytesInit) {
                 LOG_ERROR("Invalid state for receiving data");
                 goto error;
             }
             LOG_DEBUG("PUT DATA cmd %d, cookie %d sz %d", nhdr->command, nhdr->cookie, data_size);
             
-            if (fs_write(&_fd, nhdr->data, data_size) < data_size) {
+            if (fs_write(&_txn->fd, nhdr->data, data_size) < data_size) {
                 LOG_ERROR("failed to write data");
                 goto error;
             }
-            _cookie = nhdr->cookie;
-            _bytes_transferred += data_size;
+            _txn->cookie = nhdr->cookie;
+            _txn->bytes_transferred += data_size;
             
             notification_progress *prog = mem_heap_alloc(&mem_heaps[HEAP_LOWPRIO], sizeof(notification_progress));
             if (prog) {
-                prog->progress_bytes = _bytes_transferred;
-                prog->total_bytes = _total_size;
+                prog->progress_bytes = _txn->bytes_transferred;
+                prog->total_bytes = _txn->total_size;
             
                 event_service_post(EventServiceCommandProgress, prog, remote_free);
-                vTaskDelay(0);
             }
             _send_ack(packet, nhdr->cookie);
+            protocol_service_timer_start(_txn->timer, 1200);
             break;
             
         case PutBytesCommit:
-            LOG_DEBUG("Commit %d Bytes", _total_size);
+            protocol_service_timer_cancel(_txn->timer);
+            LOG_DEBUG("Commit %d Bytes", _txn->total_size);
             _transfer_put_commit_header *chdr = (_transfer_put_commit_header *)data;
-            _cookie = chdr->cookie;
+
+            if (chdr->cookie != _txn->cookie) {
+                LOG_ERROR("Invalid cookie %d expected %d", chdr->cookie, _txn->cookie);
+                goto error;
+            }
+            _txn->cookie = chdr->cookie;
             
-            if (_bytes_transferred != _total_size)
-            {
-                LOG_ERROR("Not enough data arrived %d/%d", _bytes_transferred, _total_size);
+            if (_txn->bytes_transferred != _txn->total_size) {
+                LOG_ERROR("Not enough data arrived %d/%d", _txn->bytes_transferred, _txn->total_size);
                 goto error;
             }
             
             /* CRC the file */
-            uint32_t crc = fs_file_crc32(&_fd, _bytes_transferred);
+            uint32_t crc = fs_file_crc32(&_txn->fd, _txn->bytes_transferred);
             
-            if (htonl(chdr->crc) != crc)
-            {
+            if (htonl(chdr->crc) != crc) {
                 LOG_ERROR("Bad CRC: %x expected %x", crc, htonl(chdr->crc));
                 goto error;
             }
 
-            fs_mark_written(&_fd);
+            fs_mark_written(&_txn->fd);
             LOG_DEBUG("CRC %x valid", crc);
-            
-            _send_ack(packet, _cookie);
+            protocol_service_timer_start(_txn->timer, 1200);
+            _send_ack(packet, _txn->cookie);
             break;
         
         case PutBytesInstall:
             LOG_INFO("Install App");
             _transfer_put_install_header *ihdr = (_transfer_put_install_header *)data;           
-            _cookie = ihdr->cookie;
-            _transfer_state = 0;
-            _send_ack(packet, _cookie);
-            _bytes_transferred = 0;
-            _cookie = 0;
-            
-            protocol_transaction_unlock();
-            
+            _txn->cookie = ihdr->cookie;
+             
             /* Once we have the resource, tell app manager we are good to load */
-            if (_transfer_type == TransferType_AppResource)
+            if (_txn->transfer_type == TransferType_AppResource) {
                 appmanager_app_download_complete();
-            
+            }
+            _send_ack(packet, _txn->cookie);
+            protocol_transaction_unlock();
+            protocol_service_timer_destroy(_txn->timer);
+            remote_free(_txn);
+            _txn = NULL;
             break;
             
         case PutBytesAbort:
@@ -255,8 +276,29 @@ void protocol_process_transfer(const RebblePacket packet)
     return;
     
 error:
-    _transfer_state = 0;
-    _bytes_transferred = 0;
+    _transfer_terminated(packet);
+}
+
+static void _transfer_timeout(ProtocolTimer *timer)
+{
+    LOG_ERROR("Transfer timed out after %dms", timer->timeout_ms);
+    RebblePacket packet = packet_create_with_data(WatchProtocol_PutBytes, NULL, 0);
+    packet_set_transport(packet, _txn->transport);
+    timer->on_queue = 0;
+    _transfer_terminated(packet);
+    packet_destroy(packet);
+}
+
+static void _transfer_terminated(RebblePacket packet)
+{
     _send_nack(packet, 0);
     protocol_transaction_unlock();
+    if (_txn) {
+        if (_txn->timer) {
+            protocol_service_timer_destroy(_txn->timer);
+            _txn->timer = NULL;
+        }
+        remote_free(_txn);
+    }
+    _txn = NULL;
 }

--- a/rcore/qemu.c
+++ b/rcore/qemu.c
@@ -211,7 +211,8 @@ static int _qemu_handle_packet(uint8_t *buf, size_t *len)
 
         if (header.signature != QEMU_HEADER_SIGNATURE) {
             LOG_ERROR("Invalid header signature: %x", header.signature);
-            return PACKET_INVALID;
+            rv = PACKET_INVALID;
+            goto error;
         }
 
         if (header.len > QEMU_MAX_DATA_LEN) {
@@ -270,12 +271,12 @@ static int _qemu_handle_packet(uint8_t *buf, size_t *len)
         goto error;
     }
 
-    RebblePacket p = packet_create_with_data(0, NULL, header.len);
+    RebblePacket p = packet_create_with_data(0, protocol_get_rx_buffer(), header.len);
     packet_set_transport(p, qemu_send_data);
     handler(p);
 
     if (buflen - processed > 0) {
-        memmove(buf, buf + processed, buflen - processed);
+        //memmove(buf, buf + processed, buflen - processed);
         *len = buflen - processed;
         return PACKET_BUFFER_HAS_DATA; /* more work to do */
     }

--- a/rcore/service/protocol_service.h
+++ b/rcore/service/protocol_service.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "appmanager.h"
 typedef struct rebble_packet rebble_packet;
 
 void rebble_protocol_init();
@@ -17,3 +18,17 @@ void packet_set_endpoint(RebblePacket packet, uint16_t endpoint);
 ProtocolTransportSender packet_get_transport(RebblePacket packet);
 void packet_set_transport(RebblePacket packet, ProtocolTransportSender transport);
 void packet_send_to_transport(RebblePacket packet, uint16_t endpoint, uint8_t *data, uint16_t len);
+
+typedef struct ProtocolTimer {
+    CoreTimer timer;
+    TickType_t timeout_ms;
+    uint8_t on_queue;
+} ProtocolTimer;
+
+typedef void (*ProtocolTimerCallback)(struct ProtocolTimer *) ;
+
+void protocol_service_timer_restart(ProtocolTimer *timer);
+void protocol_service_timer_start(ProtocolTimer *timer, TickType_t timeout);
+void protocol_service_timer_cancel(ProtocolTimer *timer);
+void protocol_service_timer_destroy(ProtocolTimer *timer);
+ProtocolTimer *protocol_service_timer_create(ProtocolTimerCallback callback, TickType_t timeout);

--- a/rcore/test.c
+++ b/rcore/test.c
@@ -133,6 +133,8 @@ void test_packet_handler(const RebblePacket packet)
     default:
         KERN_LOG("test", APP_LOG_LEVEL_ERROR, "unknown qemu opcode %04x", qpkt->opcode);
     }
+
+    protocol_rx_buffer_consume(packet_get_data_length(packet) + sizeof(RebblePacketHeader));
 }
 
 TEST(simple) {

--- a/rwatch/event/tick_timer_service.c
+++ b/rwatch/event/tick_timer_service.c
@@ -27,7 +27,7 @@ static void _tick_timer_update_next(TickTimerState *state)
 {
     app_running_thread *thread = appmanager_get_current_thread();
     if (state->onqueue) {
-        appmanager_timer_remove(&state->timer, thread);
+        appmanager_timer_remove(&thread->timer_head, &state->timer);
     }
     
     /* Figure out the desired time. */
@@ -66,7 +66,7 @@ static void _tick_timer_update_next(TickTimerState *state)
         when = 2;
     state->timer.when = when;
     state->timer.callback = _tick_timer_callback;
-    appmanager_timer_add(&state->timer, thread);
+    appmanager_timer_add(&thread->timer_head, &state->timer);
     state->onqueue = 1;
 }
 
@@ -118,9 +118,10 @@ void tick_timer_service_subscribe(TimeUnits tick_units, TickHandler handler)
 void tick_timer_service_unsubscribe(void)
 {
     TickTimerState *state = &_state;
-    
+    app_running_thread *thread = appmanager_get_current_thread();
+
     if (state->onqueue) {
-        appmanager_timer_remove(&state->timer, appmanager_get_current_thread());
+        appmanager_timer_remove(&thread->timer_head, &state->timer);
         state->onqueue = 0;
     }
 }
@@ -128,9 +129,9 @@ void tick_timer_service_unsubscribe(void)
 void tick_timer_service_unsubscribe_thread(app_running_thread *thread)
 {
     TickTimerState *state = &_state;
-    
+
     if (state->onqueue) {
-        appmanager_timer_remove(&state->timer, thread);
+        appmanager_timer_remove(&thread->timer_head, &state->timer);
         state->onqueue = 0;
     }
 }

--- a/rwatch/ui/layer/status_bar_layer.c
+++ b/rwatch/ui/layer/status_bar_layer.c
@@ -16,7 +16,8 @@ static void _schedule_timer(StatusBarLayer* status_bar)
 {
     TickType_t delay = pdMS_TO_TICKS(1000 * (60 - status_bar->last_time.tm_sec));
     status_bar->timer.when = xTaskGetTickCount() + delay;
-    appmanager_timer_add(&status_bar->timer, appmanager_get_current_thread());
+    app_running_thread *thread = appmanager_get_current_thread();
+    appmanager_timer_add(&thread->timer_head, &status_bar->timer);
 }
 
 static void _timer_callback(CoreTimer* timer) {


### PR DESCRIPTION
app_timer: 
make more generic so other threads can use the service

protocol:
* qemu logic now no longer abuses memmove to parse the buffer. State engine tracks the header, only then adding to the main rx buffer
* rx is processed in the service thread in a loop until exhaused. Allows single payload multi packet handling
* service timer to allow a protocol endpoint to requst a transaction timeout

transfer:
* requests a timeout per section of the transfer.
* auto NACK on timeout of the transfer
* state machine to track states