### PR TITLE
Set alignment to MenuRowAlignCenter on submenu return

### DIFF
--- a/Apps/System/menu.c
+++ b/Apps/System/menu.c
@@ -171,7 +171,7 @@ static void back_single_click_handler(ClickRecognizerRef _, Menu *menu)
         MenuItems *prev = menu->items;
         menu->items = prev->back;
         menu_layer_reload_data(menu->layer);
-        menu_layer_set_selected_index(menu->layer, prev->back_index, MenuRowAlignTop, false);
+        menu_layer_set_selected_index(menu->layer, prev->back_index, MenuRowAlignCenter, false);
         prev->back = NULL; // so we don't free that
         menu_items_destroy(prev);
     }

--- a/rwatch/ui/layer/scroll_layer.c
+++ b/rwatch/ui/layer/scroll_layer.c
@@ -147,6 +147,10 @@ void scroll_layer_set_content_offset(ScrollLayer *scroll_layer, GPoint offset, b
         animation_set_duration(anim, 100);
         animation_schedule(anim);
     }
+    else
+    {
+        layer_set_frame(&scroll_layer->content_sublayer, scroll_layer->scroll_offset);
+    }
 }
 
 GPoint scroll_layer_get_content_offset(ScrollLayer *scroll_layer)


### PR DESCRIPTION
From what I was able to trace through:
* Before entering the submenu, the menu alignment would be set to `MenuRowAlignCenter`
* When returning from the submenu, alignment would be set to `MenuRowAlignTop`.

The difference in alignment caused changes on `span_pos` and `frame_pos` in `_menu_layer_update_scroll_offset` before and after the submenu.

Fixes #132 hopefully -- if this is not the case I wouldn't mind some pointers on where else I can investigate.