### PR TITLE
#133 - Allow setting preferred watchface

### DIFF
--- a/Apps/System/systemapp.c
+++ b/Apps/System/systemapp.c
@@ -15,6 +15,7 @@
 #include "protocol.h"
 #include "protocol_music.h"
 #include "event_service.h"
+#include "watchface.h"
 
 /* Configure Logging */
 #define MODULE_NAME "sysapp"
@@ -56,6 +57,17 @@ static MenuItems* watch_list_item_selected(const MenuItem *item);
 static MenuItems* app_item_selected(const MenuItem *item)
 {
     appmanager_app_start(item->text);
+    return NULL;
+}
+
+static MenuItems* watchface_selected(const MenuItem *item)
+{
+    App * app = appmanager_get_app_by_name(item->text);
+    assert(app);
+
+    watchface_set_pref_by_uuid(&app->uuid);
+    watchface_enter();
+
     return NULL;
 }
 
@@ -103,7 +115,7 @@ static MenuItems* watch_list_item_selected(const MenuItem *item) {
         {
             continue;
         }
-        menu_items_add(items, MenuItem(app->name, NULL, RESOURCE_ID_CLOCK, app_item_selected));
+        menu_items_add(items, MenuItem(app->name, NULL, RESOURCE_ID_CLOCK, watchface_selected));
     }
     return items;
 }
@@ -129,9 +141,8 @@ static MenuItems* app_list_item_selected(const MenuItem *item) {
 static void exit_to_watchface(struct Menu *menu, void *context)
 {
     // Exit to watchface
-    appmanager_app_start("Simplicity");
+    watchface_enter();
 }
-
 
 static MusicTrackInfo *_music_track;
 static MenuItems *items;
@@ -308,6 +319,7 @@ void systemapp_init(void)
 
     window_stack_push(s_main_window, true);
     settings_init();
+    watchface_init();
 }
 
 extern void settings_deinit();

--- a/Apps/System/watchface.c
+++ b/Apps/System/watchface.c
@@ -1,0 +1,65 @@
+/* watchface.c
+ * Routines for loading watchfaces based on
+ * user preferences.
+ * 
+ * RebbleOS
+ *
+ */
+
+#include "rebbleos.h"
+#include "prefs.h"
+
+/* Configure Logging */
+#define MODULE_NAME "watchface"
+#define MODULE_TYPE "WCH"
+#define LOG_LEVEL RBL_LOG_LEVEL_DEBUG //RBL_LOG_LEVEL_NONE
+
+static Uuid _watchface;
+
+void rcore_watchface_prefs_save()
+{
+	(void) prefs_put(PREFS_KEY_WATCHFACE, &_watchface, sizeof(Uuid));
+}
+
+void rcore_watchface_prefs_load()
+{
+    if (uuid_null(&_watchface) || prefs_get(PREFS_KEY_WATCHFACE, &_watchface, sizeof(_watchface)) < 0)
+    {
+        LOG_DEBUG("No watchface preference set, using default.");
+        App * default_watchface = appmanager_get_app_by_name("Simplicity");
+        assert(default_watchface);
+
+        memcpy(&_watchface, &default_watchface->uuid, sizeof(Uuid));
+    }
+    else
+    {
+        LOG_DEBUG("Loaded watchface preference.");
+    }
+    
+    char buf[UUID_STRING_BUFFER_LENGTH];
+    uuid_to_string(&_watchface, buf);
+
+    LOG_INFO("Using watchface UUID: %s", buf);
+}
+
+void watchface_set_pref_by_uuid(Uuid *uuid)
+{
+    memcpy(&_watchface, uuid, sizeof(Uuid));
+
+    char buf[UUID_STRING_BUFFER_LENGTH];
+    uuid_to_string(&_watchface, buf);
+
+    LOG_INFO("Setting watchface preference UUID: %s", buf);
+
+    rcore_watchface_prefs_save();
+}
+
+void watchface_init()
+{
+    rcore_watchface_prefs_load();
+}
+
+void watchface_enter()
+{
+    appmanager_app_start_by_uuid(&_watchface);
+}

--- a/Apps/System/watchface.h
+++ b/Apps/System/watchface.h
@@ -1,0 +1,14 @@
+#pragma once
+/* watchface.h
+ * Routines for loading watchfaces based on
+ * user preferences.
+ * 
+ * RebbleOS
+ *
+ */
+
+void watchface_enter();
+
+void watchface_init();
+
+void watchface_set_pref_by_uuid(Uuid *uuid);

--- a/config.mk
+++ b/config.mk
@@ -176,6 +176,7 @@ SRCS_all += Apps/System/menu.c
 SRCS_all += Apps/System/testapp.c
 SRCS_all += Apps/System/settings.c
 SRCS_all += Apps/System/settings_tz.c
+SRCS_all += Apps/System/watchface.c
 
 SRCS_all += Apps/System/widgettest.c
 SRCS_all += Apps/System/notification.c

--- a/rcore/prefs.h
+++ b/rcore/prefs.h
@@ -3,6 +3,7 @@
 enum prefs_key {
     PREFS_KEY_TZ,
     PREFS_KEY_IS24H,
+    PREFS_KEY_WATCHFACE,
 };
 
 int prefs_get(const uint32_t key, void *buf, uint32_t bufsz);


### PR DESCRIPTION
Persists the user's preferred watchface with the persistence API by the app UUID.
