### PR TITLE
Various fixes for porting dialog choice in ui-patterns

### DIFF
--- a/rwatch/graphics/graphics.c
+++ b/rwatch/graphics/graphics.c
@@ -282,7 +282,7 @@ GRect grect_inset(GRect rect, GEdgeInsets insets)
     GRect r;
     // top, right, bottom, left
     r.origin.x = insets.left;
-    r.origin.x = insets.top;
+    r.origin.y = insets.top;
     r.size.w = rect.size.w - insets.right - insets.left;
     r.size.h = rect.size.h - insets.top - insets.bottom;
     return r;

--- a/rwatch/ui/layer/action_bar_layer.c
+++ b/rwatch/ui/layer/action_bar_layer.c
@@ -21,7 +21,8 @@ ActionBarLayer *action_bar_layer_create()
     layer->container = action_bar;
     action_bar->layer = layer;
     action_bar->context = action_bar;
-    
+    action_bar->background_color = GColorBlack;
+
     layer_set_update_proc(layer, draw);
     
     return action_bar;

--- a/rwatch/ui/layer/bitmap_layer.c
+++ b/rwatch/ui/layer/bitmap_layer.c
@@ -18,7 +18,7 @@ void bitmap_layer_ctor(BitmapLayer *blayer, GRect frame)
     // give the layer a reference back to us
     blayer->layer.container = blayer;
     blayer->compositing_mode = GCompOpAssign;
-    blayer->background = GColorWhite;
+    blayer->background = GColorClear;
     blayer->alignment = GAlignCenter;
     
     layer_set_update_proc(&blayer->layer, _bitmap_update_proc);
@@ -82,13 +82,13 @@ static void _bitmap_update_proc(Layer *layer, GContext *nGContext)
     uint16_t x, y;
     uint16_t bw = bitmap_layer->bitmap->bounds.size.w;
     uint16_t bh = bitmap_layer->bitmap->bounds.size.h;
-    uint16_t lx = layer->bounds.origin.x;
-    uint16_t ly = layer->bounds.origin.y;
+    uint16_t lx = layer->window->frame.origin.x + layer->frame.origin.x;
+    uint16_t ly = layer->window->frame.origin.y + layer->frame.origin.y;
     uint16_t lw = layer->bounds.size.w;
     uint16_t lh = layer->bounds.size.h;
     
 //     printf("LX %d LY %d LW %d LH %d BW %d BH %d\n", lx, ly, lw, lh, bw, bh);
-        
+
     switch (bitmap_layer->alignment)
     {
         case GAlignCenter:
@@ -136,6 +136,7 @@ static void _bitmap_update_proc(Layer *layer, GContext *nGContext)
 
     // fill the background
     graphics_context_set_fill_color(nGContext, bitmap_layer->background);
+    graphics_context_set_compositing_mode(nGContext, bitmap_layer->compositing_mode);
     graphics_fill_rect(nGContext, layer->bounds, 0, GCornerNone);
     n_graphics_draw_bitmap_in_rect(nGContext, bitmap_layer->bitmap, target);
 }


### PR DESCRIPTION
Some fixes to be compatible with the choice dialog in [ui-patterns](https://github.com/pebble-examples/ui-patterns#choice-dialog)

Before:

https://user-images.githubusercontent.com/11605757/110197587-c5024d80-7e09-11eb-9d5f-e47261b99c6b.mp4

After:

https://user-images.githubusercontent.com/11605757/110197591-cb90c500-7e09-11eb-99dd-f14cd401d64b.mp4

Changes:
* Apply default black background to ActionBarLayer
* Apply default background to BitmapLayer
* Set correct compositing mode before drawing the bitmap
* Use frame for positioning the bitmap
* Calculate the target GRect for bitmap based on window (avoids "floating" Bitmap)

Depends on https://github.com/pebble-dev/neographics/pull/9