### PR TITLE
events: fix double free with multiple subscribers

### DIFF
--- a/rwatch/event/event_service.c
+++ b/rwatch/event/event_service.c
@@ -26,23 +26,6 @@ typedef struct event_service_subscriber {
     list_node node;
 } event_service_subscriber;
 
-// static void _event_subscriber_insert(event_service_subscriber *conn)
-// {
-//     // subs in the main app thread are first
-//     // subs in the overlay thread after
-//     list_init_node(&conn->node);
-
-//     if (&conn->thread->thread_type == AppThreadMainApp)
-//     {
-//         // list_insert_before(&_subscriber_list_head, &_subscriber_list_head.node, &conn->node);
-//         list_insert_head(&_subscriber_list_head, &conn->node);
-//     }
-//     else
-//     {
-//         list_insert_before(&_subscriber_list_head, &_subscriber_list_head.node, &conn->node);
-//     }
-// }
-
 void event_service_subscribe(EventServiceCommand command, EventServiceProc callback)
 {
     app_running_thread *_this_thread = appmanager_get_current_thread();

--- a/rwatch/event/event_service.c
+++ b/rwatch/event/event_service.c
@@ -26,6 +26,23 @@ typedef struct event_service_subscriber {
     list_node node;
 } event_service_subscriber;
 
+// static void _event_subscriber_insert(event_service_subscriber *conn)
+// {
+//     // subs in the main app thread are first
+//     // subs in the overlay thread after
+//     list_init_node(&conn->node);
+
+//     if (&conn->thread->thread_type == AppThreadMainApp)
+//     {
+//         // list_insert_before(&_subscriber_list_head, &_subscriber_list_head.node, &conn->node);
+//         list_insert_head(&_subscriber_list_head, &conn->node);
+//     }
+//     else
+//     {
+//         list_insert_before(&_subscriber_list_head, &_subscriber_list_head.node, &conn->node);
+//     }
+// }
+
 void event_service_subscribe(EventServiceCommand command, EventServiceProc callback)
 {
     app_running_thread *_this_thread = appmanager_get_current_thread();
@@ -139,22 +156,38 @@ void event_service_event_trigger(EventServiceCommand command, void *data, Destro
     {
         if (conn->command == command)
         {
-//             LOG_INFO("Triggering %x %x %x", data, destroy, conn->callback);
+            LOG_DEBUG(
+                "Checking %s subscriber %x for event type %x",
+                conn->thread->thread_type == AppThreadMainApp ? "main" : "overlay",
+                conn,
+                command);
+
+            /* Step 1. Invoke the subscriber callback - this can either
+             * be a handler on the app or overlay thread */
             if (conn->thread == _this_thread && conn->callback)
-                conn->callback(command, data, conn->context);
-            
-            /* Step 2. App processing done, post it to overlay thread */
-            if (_this_thread->thread_type == AppThreadMainApp)
-                overlay_window_post_event(command, data, destroy);
-                
-            /* Step 3. if we are the overlay thread, then destroy this packet */
-            else if (_this_thread->thread_type == AppThreadOverlay)
             {
-                if (destroy)
-                    destroy(data);
-                    
-                appmanager_post_draw_message(1);
+                LOG_DEBUG("Triggering callback %x with %x %x", conn->callback, command, data);
+                conn->callback(command, data, conn->context);
             }
         }
+    }
+
+    /* Step 2. Subscriber is done, post it to overlay thread if this is the main thread */
+    if (_this_thread->thread_type == AppThreadMainApp)
+    {
+        LOG_DEBUG("Posting event to overlay thread %x %x %x", command, data, destroy);
+        overlay_window_post_event(command, data, destroy);
+    }
+        
+    /* Step 3. if we are the overlay thread, then destroy this packet */
+    else if (_this_thread->thread_type == AppThreadOverlay)
+    {
+        if (destroy)
+        {
+            LOG_DEBUG("Destroying event packet data %x", data);
+            destroy(data);
+        }
+
+        appmanager_post_draw_message(1);
     }
 }


### PR DESCRIPTION
This fixes a double free that occurs when you have multiple subscribers on the same event on the app and overlay threads.

If we have two subscribers (one in the app thread and one in the overlay thread), then the event was being posted to the overlay thread for every subscriber - thus the packet was being destroyed twice

This was encountered when adding a subscriber in notification.c for new notifications.

With this change, subscribers are executed first, then a single post to the overlay thread is made.

